### PR TITLE
Remove feature preventing compilation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@
 
 #![crate_name="capnpc"]
 #![crate_type = "lib"]
-#![feature(box_syntax, collections, core, io, os, path, std_misc)]
+#![feature(box_syntax, core, io, os, path, std_misc)]
 
 extern crate capnp;
 


### PR DESCRIPTION
On new rustc, "collection" prevents compilation.

You probably want to wait until new rustc nightly is produced though, or Travis will fail to build it.