### PR TITLE
Workaroung for using ::capnpc::compile on Windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,10 +60,16 @@ pub fn compile(prefix : &::std::path::Path, files : &[&::std::path::Path]) -> ::
     //
     // TODO: Once a released version of `capnp compile` includes the '-o -' option, switch to
     //       using that. (see https://github.com/sandstorm-io/capnproto/pull/190)
-    let which_output = ::std::process::Command::new("which").arg("cat").output().unwrap().stdout;
+    let cat_file = match ::std::process::Command::new("which").arg("cat").output() {
+        Ok(result) => match result.status.success() {
+		true => result.stdout,
+		false => vec!(b'-'),
+	},
+        Err(_) => vec!(b'-'),
+    };
 
     let mut command = ::std::process::Command::new("capnp");
-    command.arg("compile").arg("-o").arg(&::std::str::from_utf8(&which_output).unwrap().trim())
+    command.arg("compile").arg("-o").arg(&::std::str::from_utf8(&cat_file).unwrap().trim())
            .arg(&format!("--src-prefix={}", prefix.display()));
 
     for file in files.iter() {


### PR DESCRIPTION
When you try to use the project under Windows, I got the error due to the lack of ```which``` command.
As a result of this hotfix generation rust-files should work on the upcoming release of capnproto out of the box.

This change does not look nice, but it may be useful: quickly remove the use of ```which cat``` will not be able by legacy reason (for example: Ubuntu 14.04 LTS have capnp 0.4.0).

In addition, I build capnproto version for Windows: https://github.com/bozaro/capnproto/releases/tag/v0.5.1.2-pr190