### PR TITLE
Rework traits HasTypeId and HasStructSize

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1111,7 +1111,7 @@ fn generate_node(node_map : &collections::hash_map::HashMap<u64, schema_capnp::n
                         Line("impl <'a> ::capnp::traits::HasStructSize for Builder<'a> {".to_string()),
                         Indent(Box::new(
                             Branch(vec!(Line("#[inline]".to_string()),
-                                        Line("fn struct_size(_unused_self : Option<Builder>) -> layout::StructSize { _private::STRUCT_SIZE }".to_string()))))),
+                                        Line("fn struct_size() -> layout::StructSize { _private::STRUCT_SIZE }".to_string()))))),
                        Line("}".to_string())))
             };
 

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1156,7 +1156,7 @@ fn generate_node(node_map : &collections::hash_map::HashMap<u64, schema_capnp::n
                 Branch(vec!(
                         Line("impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {".to_string()),
                         Indent(Box::new(Branch(vec!(Line("#[inline]".to_string()),
-                                               Line("fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }".to_string()))))),
+                                               Line("fn type_id() -> u64 { _private::TYPE_ID }".to_string()))))),
                     Line("}".to_string()))),
                 Line("impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {".to_string()),
                 Indent(
@@ -1198,7 +1198,7 @@ fn generate_node(node_map : &collections::hash_map::HashMap<u64, schema_capnp::n
                 Branch(vec!(
                         Line("impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {".to_string()),
                         Indent(Box::new(Branch(vec!(Line("#[inline]".to_string()),
-                                                    Line("fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }".to_string()))))),
+                                                    Line("fn type_id() -> u64 { _private::TYPE_ID }".to_string()))))),
                                Line("}".to_string()))),
                 Line("impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {".to_string()),
                 Indent(
@@ -1310,7 +1310,7 @@ fn generate_node(node_map : &collections::hash_map::HashMap<u64, schema_capnp::n
                     Line(format!("impl ::capnp::traits::HasTypeId for {} {{", *names.last().unwrap())),
                     Indent(Box::new(Line("#[inline]".to_string()))),
                     Indent(
-                        Box::new(Line(format!("fn type_id(_unused_self : Option<{}>) -> u64 {{ {:#x}u64 }}", *names.last().unwrap(), node_id).to_string()))),
+                        Box::new(Line(format!("fn type_id() -> u64 {{ {:#x}u64 }}", node_id).to_string()))),
                     Line("}".to_string()))));
         }
 
@@ -1433,7 +1433,7 @@ fn generate_node(node_map : &collections::hash_map::HashMap<u64, schema_capnp::n
                     Branch(vec!(
                         Line("impl ::capnp::traits::HasTypeId for Client {".to_string()),
                         Indent(Box::new(Line("#[inline]".to_string()))),
-                        Indent(Box::new(Line("fn type_id(_unused_self : Option<Client>) -> u64 { _private::TYPE_ID }".to_string()))),
+                        Indent(Box::new(Line("fn type_id() -> u64 { _private::TYPE_ID }".to_string()))),
                         Line("}".to_string()))));
 
 

--- a/src/schema_capnp.rs
+++ b/src/schema_capnp.rs
@@ -18,7 +18,7 @@ pub mod node {
 
   impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
     #[inline]
-    fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+    fn type_id() -> u64 { _private::TYPE_ID }
   }
   impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
     fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -133,7 +133,7 @@ pub mod node {
   }
   impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
     #[inline]
-    fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+    fn type_id() -> u64 { _private::TYPE_ID }
   }
   impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
     fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -390,7 +390,7 @@ pub mod node {
 
     impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
       fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -432,7 +432,7 @@ pub mod node {
     }
     impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
       fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -513,7 +513,7 @@ pub mod node {
 
     impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
       fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -559,7 +559,7 @@ pub mod node {
     }
     impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
       fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -648,7 +648,7 @@ pub mod node {
 
     impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
       fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -710,7 +710,7 @@ pub mod node {
     pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
     impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
       fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -828,7 +828,7 @@ pub mod node {
 
     impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
       fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -866,7 +866,7 @@ pub mod node {
     pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
     impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
       fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -936,7 +936,7 @@ pub mod node {
 
     impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
       fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -981,7 +981,7 @@ pub mod node {
     pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
     impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
       fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -1066,7 +1066,7 @@ pub mod node {
 
     impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
       fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -1111,7 +1111,7 @@ pub mod node {
     pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
     impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
       fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -1202,7 +1202,7 @@ pub mod node {
 
     impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
       fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -1288,7 +1288,7 @@ pub mod node {
     pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
     impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
       fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -1460,7 +1460,7 @@ pub mod field {
 
   impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
     #[inline]
-    fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+    fn type_id() -> u64 { _private::TYPE_ID }
   }
   impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
     fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -1537,7 +1537,7 @@ pub mod field {
   }
   impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
     #[inline]
-    fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+    fn type_id() -> u64 { _private::TYPE_ID }
   }
   impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
     fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -1699,7 +1699,7 @@ pub mod field {
 
     impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
       fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -1752,7 +1752,7 @@ pub mod field {
     pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
     impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
       fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -1859,7 +1859,7 @@ pub mod field {
 
     impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
       fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -1894,7 +1894,7 @@ pub mod field {
     pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
     impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
       fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -1959,7 +1959,7 @@ pub mod field {
 
     impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
       fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -2006,7 +2006,7 @@ pub mod field {
     pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
     impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
       fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -2093,7 +2093,7 @@ pub mod enumerant {
 
   impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
     #[inline]
-    fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+    fn type_id() -> u64 { _private::TYPE_ID }
   }
   impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
     fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -2146,7 +2146,7 @@ pub mod enumerant {
   }
   impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
     #[inline]
-    fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+    fn type_id() -> u64 { _private::TYPE_ID }
   }
   impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
     fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -2250,7 +2250,7 @@ pub mod superclass {
 
   impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
     #[inline]
-    fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+    fn type_id() -> u64 { _private::TYPE_ID }
   }
   impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
     fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -2296,7 +2296,7 @@ pub mod superclass {
   }
   impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
     #[inline]
-    fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+    fn type_id() -> u64 { _private::TYPE_ID }
   }
   impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
     fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -2388,7 +2388,7 @@ pub mod method {
 
   impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
     #[inline]
-    fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+    fn type_id() -> u64 { _private::TYPE_ID }
   }
   impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
     fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -2470,7 +2470,7 @@ pub mod method {
   }
   impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
     #[inline]
-    fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+    fn type_id() -> u64 { _private::TYPE_ID }
   }
   impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
     fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -2643,7 +2643,7 @@ pub mod type_ {
 
   impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
     #[inline]
-    fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+    fn type_id() -> u64 { _private::TYPE_ID }
   }
   impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
     fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -2779,7 +2779,7 @@ pub mod type_ {
   }
   impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
     #[inline]
-    fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+    fn type_id() -> u64 { _private::TYPE_ID }
   }
   impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
     fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -3061,7 +3061,7 @@ pub mod type_ {
 
     impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
       fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -3099,7 +3099,7 @@ pub mod type_ {
     pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
     impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
       fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -3172,7 +3172,7 @@ pub mod type_ {
 
     impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
       fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -3214,7 +3214,7 @@ pub mod type_ {
     pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
     impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
       fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -3295,7 +3295,7 @@ pub mod type_ {
 
     impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
       fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -3337,7 +3337,7 @@ pub mod type_ {
     pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
     impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
       fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -3418,7 +3418,7 @@ pub mod type_ {
 
     impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
       fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -3460,7 +3460,7 @@ pub mod type_ {
     pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
     impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
       fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -3543,7 +3543,7 @@ pub mod type_ {
 
     impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
       fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -3595,7 +3595,7 @@ pub mod type_ {
     pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
     impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
       fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -3698,7 +3698,7 @@ pub mod type_ {
 
       impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
         #[inline]
-        fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+        fn type_id() -> u64 { _private::TYPE_ID }
       }
       impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
         fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -3755,7 +3755,7 @@ pub mod type_ {
       pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
       impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
         #[inline]
-        fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+        fn type_id() -> u64 { _private::TYPE_ID }
       }
       impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
         fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -3860,7 +3860,7 @@ pub mod type_ {
 
       impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
         #[inline]
-        fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+        fn type_id() -> u64 { _private::TYPE_ID }
       }
       impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
         fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -3899,7 +3899,7 @@ pub mod type_ {
       pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
       impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
         #[inline]
-        fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+        fn type_id() -> u64 { _private::TYPE_ID }
       }
       impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
         fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -3970,7 +3970,7 @@ pub mod type_ {
 
       impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
         #[inline]
-        fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+        fn type_id() -> u64 { _private::TYPE_ID }
       }
       impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
         fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -4005,7 +4005,7 @@ pub mod type_ {
       pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
       impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
         #[inline]
-        fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+        fn type_id() -> u64 { _private::TYPE_ID }
       }
       impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
         fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -4070,7 +4070,7 @@ pub mod brand {
 
   impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
     #[inline]
-    fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+    fn type_id() -> u64 { _private::TYPE_ID }
   }
   impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
     fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -4112,7 +4112,7 @@ pub mod brand {
   }
   impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
     #[inline]
-    fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+    fn type_id() -> u64 { _private::TYPE_ID }
   }
   impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
     fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -4194,7 +4194,7 @@ pub mod brand {
 
     impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
       fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -4253,7 +4253,7 @@ pub mod brand {
     }
     impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
       fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -4369,7 +4369,7 @@ pub mod brand {
 
     impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
       fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -4424,7 +4424,7 @@ pub mod brand {
     }
     impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
       fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -4533,7 +4533,7 @@ pub mod value {
 
   impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
     #[inline]
-    fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+    fn type_id() -> u64 { _private::TYPE_ID }
   }
   impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
     fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -4689,7 +4689,7 @@ pub mod value {
   }
   impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
     #[inline]
-    fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+    fn type_id() -> u64 { _private::TYPE_ID }
   }
   impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
     fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -5008,7 +5008,7 @@ pub mod annotation {
 
   impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
     #[inline]
-    fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+    fn type_id() -> u64 { _private::TYPE_ID }
   }
   impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
     fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -5061,7 +5061,7 @@ pub mod annotation {
   }
   impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
     #[inline]
-    fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+    fn type_id() -> u64 { _private::TYPE_ID }
   }
   impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
     fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -5192,7 +5192,7 @@ impl ::capnp::traits::ToU16 for ElementSize {
 }
 impl ::capnp::traits::HasTypeId for ElementSize {
   #[inline]
-  fn type_id(_unused_self : Option<ElementSize>) -> u64 { 0xd1958f7dba521926u64 }
+  fn type_id() -> u64 { 0xd1958f7dba521926u64 }
 }
 
 pub mod code_generator_request {
@@ -5208,7 +5208,7 @@ pub mod code_generator_request {
 
   impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
     #[inline]
-    fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+    fn type_id() -> u64 { _private::TYPE_ID }
   }
   impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
     fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -5257,7 +5257,7 @@ pub mod code_generator_request {
   }
   impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
     #[inline]
-    fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+    fn type_id() -> u64 { _private::TYPE_ID }
   }
   impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
     fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -5352,7 +5352,7 @@ pub mod code_generator_request {
 
     impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
       fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -5405,7 +5405,7 @@ pub mod code_generator_request {
     }
     impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
       #[inline]
-      fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+      fn type_id() -> u64 { _private::TYPE_ID }
     }
     impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
       fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
@@ -5508,7 +5508,7 @@ pub mod code_generator_request {
 
       impl <'a> ::capnp::traits::HasTypeId for Reader<'a> {
         #[inline]
-        fn type_id(_unused_self : Option<Reader>) -> u64 { _private::TYPE_ID }
+        fn type_id() -> u64 { _private::TYPE_ID }
       }
       impl <'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
         fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
@@ -5554,7 +5554,7 @@ pub mod code_generator_request {
       }
       impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
         #[inline]
-        fn type_id(_unused_self : Option<Builder>) -> u64 { _private::TYPE_ID }
+        fn type_id() -> u64 { _private::TYPE_ID }
       }
       impl <'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
         fn new(builder : ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {

--- a/src/schema_capnp.rs
+++ b/src/schema_capnp.rs
@@ -129,7 +129,7 @@ pub mod node {
   pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
   impl <'a> ::capnp::traits::HasStructSize for Builder<'a> {
     #[inline]
-    fn struct_size(_unused_self : Option<Builder>) -> layout::StructSize { _private::STRUCT_SIZE }
+    fn struct_size() -> layout::StructSize { _private::STRUCT_SIZE }
   }
   impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
     #[inline]
@@ -428,7 +428,7 @@ pub mod node {
     pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
     impl <'a> ::capnp::traits::HasStructSize for Builder<'a> {
       #[inline]
-      fn struct_size(_unused_self : Option<Builder>) -> layout::StructSize { _private::STRUCT_SIZE }
+      fn struct_size() -> layout::StructSize { _private::STRUCT_SIZE }
     }
     impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
       #[inline]
@@ -555,7 +555,7 @@ pub mod node {
     pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
     impl <'a> ::capnp::traits::HasStructSize for Builder<'a> {
       #[inline]
-      fn struct_size(_unused_self : Option<Builder>) -> layout::StructSize { _private::STRUCT_SIZE }
+      fn struct_size() -> layout::StructSize { _private::STRUCT_SIZE }
     }
     impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
       #[inline]
@@ -1533,7 +1533,7 @@ pub mod field {
   pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
   impl <'a> ::capnp::traits::HasStructSize for Builder<'a> {
     #[inline]
-    fn struct_size(_unused_self : Option<Builder>) -> layout::StructSize { _private::STRUCT_SIZE }
+    fn struct_size() -> layout::StructSize { _private::STRUCT_SIZE }
   }
   impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
     #[inline]
@@ -2142,7 +2142,7 @@ pub mod enumerant {
   pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
   impl <'a> ::capnp::traits::HasStructSize for Builder<'a> {
     #[inline]
-    fn struct_size(_unused_self : Option<Builder>) -> layout::StructSize { _private::STRUCT_SIZE }
+    fn struct_size() -> layout::StructSize { _private::STRUCT_SIZE }
   }
   impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
     #[inline]
@@ -2292,7 +2292,7 @@ pub mod superclass {
   pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
   impl <'a> ::capnp::traits::HasStructSize for Builder<'a> {
     #[inline]
-    fn struct_size(_unused_self : Option<Builder>) -> layout::StructSize { _private::STRUCT_SIZE }
+    fn struct_size() -> layout::StructSize { _private::STRUCT_SIZE }
   }
   impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
     #[inline]
@@ -2466,7 +2466,7 @@ pub mod method {
   pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
   impl <'a> ::capnp::traits::HasStructSize for Builder<'a> {
     #[inline]
-    fn struct_size(_unused_self : Option<Builder>) -> layout::StructSize { _private::STRUCT_SIZE }
+    fn struct_size() -> layout::StructSize { _private::STRUCT_SIZE }
   }
   impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
     #[inline]
@@ -2775,7 +2775,7 @@ pub mod type_ {
   pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
   impl <'a> ::capnp::traits::HasStructSize for Builder<'a> {
     #[inline]
-    fn struct_size(_unused_self : Option<Builder>) -> layout::StructSize { _private::STRUCT_SIZE }
+    fn struct_size() -> layout::StructSize { _private::STRUCT_SIZE }
   }
   impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
     #[inline]
@@ -4108,7 +4108,7 @@ pub mod brand {
   pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
   impl <'a> ::capnp::traits::HasStructSize for Builder<'a> {
     #[inline]
-    fn struct_size(_unused_self : Option<Builder>) -> layout::StructSize { _private::STRUCT_SIZE }
+    fn struct_size() -> layout::StructSize { _private::STRUCT_SIZE }
   }
   impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
     #[inline]
@@ -4249,7 +4249,7 @@ pub mod brand {
     pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
     impl <'a> ::capnp::traits::HasStructSize for Builder<'a> {
       #[inline]
-      fn struct_size(_unused_self : Option<Builder>) -> layout::StructSize { _private::STRUCT_SIZE }
+      fn struct_size() -> layout::StructSize { _private::STRUCT_SIZE }
     }
     impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
       #[inline]
@@ -4420,7 +4420,7 @@ pub mod brand {
     pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
     impl <'a> ::capnp::traits::HasStructSize for Builder<'a> {
       #[inline]
-      fn struct_size(_unused_self : Option<Builder>) -> layout::StructSize { _private::STRUCT_SIZE }
+      fn struct_size() -> layout::StructSize { _private::STRUCT_SIZE }
     }
     impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
       #[inline]
@@ -4685,7 +4685,7 @@ pub mod value {
   pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
   impl <'a> ::capnp::traits::HasStructSize for Builder<'a> {
     #[inline]
-    fn struct_size(_unused_self : Option<Builder>) -> layout::StructSize { _private::STRUCT_SIZE }
+    fn struct_size() -> layout::StructSize { _private::STRUCT_SIZE }
   }
   impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
     #[inline]
@@ -5057,7 +5057,7 @@ pub mod annotation {
   pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
   impl <'a> ::capnp::traits::HasStructSize for Builder<'a> {
     #[inline]
-    fn struct_size(_unused_self : Option<Builder>) -> layout::StructSize { _private::STRUCT_SIZE }
+    fn struct_size() -> layout::StructSize { _private::STRUCT_SIZE }
   }
   impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
     #[inline]
@@ -5253,7 +5253,7 @@ pub mod code_generator_request {
   pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
   impl <'a> ::capnp::traits::HasStructSize for Builder<'a> {
     #[inline]
-    fn struct_size(_unused_self : Option<Builder>) -> layout::StructSize { _private::STRUCT_SIZE }
+    fn struct_size() -> layout::StructSize { _private::STRUCT_SIZE }
   }
   impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
     #[inline]
@@ -5401,7 +5401,7 @@ pub mod code_generator_request {
     pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
     impl <'a> ::capnp::traits::HasStructSize for Builder<'a> {
       #[inline]
-      fn struct_size(_unused_self : Option<Builder>) -> layout::StructSize { _private::STRUCT_SIZE }
+      fn struct_size() -> layout::StructSize { _private::STRUCT_SIZE }
     }
     impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
       #[inline]
@@ -5550,7 +5550,7 @@ pub mod code_generator_request {
       pub struct Builder<'a> { builder : ::capnp::private::layout::StructBuilder<'a> }
       impl <'a> ::capnp::traits::HasStructSize for Builder<'a> {
         #[inline]
-        fn struct_size(_unused_self : Option<Builder>) -> layout::StructSize { _private::STRUCT_SIZE }
+        fn struct_size() -> layout::StructSize { _private::STRUCT_SIZE }
       }
       impl <'a> ::capnp::traits::HasTypeId for Builder<'a> {
         #[inline]


### PR DESCRIPTION
Follow changes for `HasTypeId` and `HasStructSize` introduced in dwrensha/capnproto-rust#40