### PR TITLE
trivial bug fix in type stringification

### DIFF
--- a/src/codegen_types.rs
+++ b/src/codegen_types.rs
@@ -123,7 +123,7 @@ impl <'a> RustTypeInfo for type_::Reader<'a> {
             },
             type_::Interface(interface) => {
                 let the_mod = gen.scope_map[&interface.get_type_id()].connect("::");
-                format!("{}::Client>", the_mod)
+                format!("{}::Client", the_mod)
             },
             type_::AnyPointer(pointer) => {
                 match pointer.which().unwrap() {

--- a/test/test.capnp
+++ b/test/test.capnp
@@ -328,8 +328,7 @@ struct TestUseGenerics $TestGenerics(Text, Data).ann("foo") {
   wrapper @8 :TestGenericsWrapper(TestAllTypes, TestAnyPointer);
   cap @18 :TestGenerics(TestInterface, Text);
 
-#  Currently broken:
-#  genericCap @19 :TestGenerics(TestAllTypes, List(UInt32)).Interface(Data);
+  genericCap @19 :TestGenerics(TestAllTypes, List(UInt32)).Interface(Data);
 
   default @5 :TestGenerics(TestAllTypes, Text) =
       (foo = (int16Field = 123), rev = (foo = "text", rev = (foo = (int16Field = 321))));


### PR DESCRIPTION
That one is so obvious it shows how bad we were in terms of coverage, I guess.

I can't think of anyway merging this would degrade the current situation. Less trivial stuff kept for tomorrow as planned.