### PR TITLE
Changed member get accessors' self to readonly reference.

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -959,7 +959,7 @@ fn generate_node(gen: &GeneratorContext,
                     reader_members.push(
                         Branch(vec!(
                             Line("#[inline]".to_string()),
-                            Line(format!("pub fn get_{}(self) -> {} {{", styled_name, ty)),
+                            Line(format!("pub fn get_{}(&self) -> {} {{", styled_name, ty)),
                             Indent(Box::new(get)),
                             Line("}".to_string()))));
 
@@ -968,7 +968,7 @@ fn generate_node(gen: &GeneratorContext,
                     builder_members.push(
                         Branch(vec!(
                             Line("#[inline]".to_string()),
-                            Line(format!("pub fn get_{}(self) -> {} {{", styled_name, ty_b)),
+                            Line(format!("pub fn get_{}(&self) -> {} {{", styled_name, ty_b)),
                             Indent(Box::new(get_b)),
                             Line("}".to_string()))));
 


### PR DESCRIPTION
Passing self to get accessors by reference instead of value helps avoiding move of instance after each call on Builder, which is not Copyable. I suppose passing by reference also helps with Reader's performance.