### PR TITLE
Better error msg when failing to execute capnp bin

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,8 @@ pub fn compile<P1, P2>(prefix : P1, files : &[P2]) -> ::capnp::Result<()>
     command.stdout(::std::process::Stdio::piped());
     command.stderr(::std::process::Stdio::inherit());
 
-    let mut p =  try!(command.spawn());
+    let mut p = command.spawn()
+        .unwrap_or_else(|e| { panic!("failed to execute capnp binary: {}", e) });
     try!(::codegen::main(p.stdout.take().unwrap(),
                          ::std::path::Path::new(&::std::env::var("OUT_DIR").unwrap())));
     try!(p.wait());


### PR DESCRIPTION
This adds a context to the error that is display when the capnp binary does not exist.

$ cargo build
   Compiling capnpc v0.4.3 (https://github.com/Osso/capnpc-rust.git#f9f49650)
   Compiling rust_fluent_test v0.1.0 (file:///Users/osso/Projects/giroscopio/rust-fluent-test)
failed to run custom build command for `rust_fluent_test v0.1.0 (file:///Users/osso/Projects/giroscopio/rust-fluent-test)`
Process didn't exit successfully: `/Users/osso/Projects/giroscopio/rust-fluent-test/target/debug/build/rust_fluent_test-7d318d23ef6a7992/build-script-build` (exit code: 101)
--- stderr
thread '<main>' panicked at 'failed to execute capnp binary: No such file or directory (os error 2)', /Users/osso/.cargo/git/checkouts/capnpc-rust-8a111bdd43a99181/master/src/lib.rs:73
